### PR TITLE
Version lock numpy<1.24

### DIFF
--- a/ggce/_tests/mpi/test_literature_mpi.py
+++ b/ggce/_tests/mpi/test_literature_mpi.py
@@ -293,7 +293,6 @@ EFB_Figure6_k2_params = {
     ],
 )
 def test_prb_82_085116_2010(p):
-
     COMM = MPI.COMM_WORLD
 
     gt = p["gt"]

--- a/ggce/_tests/petsc/test_hp_fint_petsc.py
+++ b/ggce/_tests/petsc/test_hp_fint_petsc.py
@@ -161,7 +161,6 @@ model_hpt = {
     ],
 )
 def test_zero_vs_tiny_T(p):
-
     COMM = MPI.COMM_WORLD
 
     k = p[0]["k"]

--- a/ggce/_tests/petsc/test_literature_finT_petsc.py
+++ b/ggce/_tests/petsc/test_literature_finT_petsc.py
@@ -161,7 +161,6 @@ H_Figure8c_q = {
     [H_Figure8a, H_Figure8c],
 )
 def test_prb_102_165155_2020(p):
-
     COMM = MPI.COMM_WORLD
     gt = np.array(p["gt"])
     model = Model.from_parameters(**p["model_params"])

--- a/ggce/_tests/petsc/test_literature_petsc.py
+++ b/ggce/_tests/petsc/test_literature_petsc.py
@@ -302,7 +302,6 @@ EFB_Figure6_k2_params = {
     ],
 )
 def test_prb_82_085116_2010(p):
-
     COMM = MPI.COMM_WORLD
     gt = p["gt"]
     model = Model.from_parameters(**p["model_params"])

--- a/ggce/_tests/petsc/test_literature_petsc_brigades.py
+++ b/ggce/_tests/petsc/test_literature_petsc_brigades.py
@@ -302,7 +302,6 @@ EFB_Figure6_k2_params = {
     ],
 )
 def test_prb_82_085116_2010(p):
-
     COMM = MPI.COMM_WORLD
     size = COMM.Get_size()
     gt = p["gt"]

--- a/ggce/_tests/petsc/test_petsc_sysgen.py
+++ b/ggce/_tests/petsc/test_petsc_sysgen.py
@@ -314,7 +314,6 @@ EFB_Figure6_k2_params = {
     ],
 )
 def test_prb_82_085116_2010(p):
-
     COMM = MPI.COMM_WORLD
 
     gt = p["gt"]

--- a/ggce/_tests/test_engine_terms.py
+++ b/ggce/_tests/test_engine_terms.py
@@ -39,7 +39,6 @@ class TestConfig:
 
     @staticmethod
     def test_1d_check_config_warning():
-
         arr = (np.random.random(size=(2, 3, 3, 3, 4)) + 1.5).astype(int)
         with _testing_mode():
             with warnings.catch_warnings(record=True) as w:

--- a/ggce/_tests/test_hp_fint.py
+++ b/ggce/_tests/test_hp_fint.py
@@ -141,7 +141,6 @@ model_hpt = {
     ],
 )
 def test_zero_vs_tiny_T(p):
-
     k = p[0]["k"]
     w = np.linspace(-2, 0, 10)
 

--- a/ggce/_tests/test_model.py
+++ b/ggce/_tests/test_model.py
@@ -18,7 +18,6 @@ from ggce.model import model_coupling_map, SingleTerm, Hamiltonian
     ],
 )
 def test_model_coupling_map(coupling_type, t, Omega, lam):
-
     # This ground truth value is just copied from a version of the
     # model_coupling_map that is known to work
     def ground_truth(coupling_type, t, Omega, lam):

--- a/ggce/engine/equations.py
+++ b/ggce/engine/equations.py
@@ -237,17 +237,14 @@ class Equation(MSONable):
 
         # Iterate over all possible types of the coupling operators
         for hterm in self._model.hamiltonian.terms:
-
             bt = hterm.phonon_index  # Phonon type
             arr = self.index_term.config.config[bt, ...]
 
             # We separate the two cases for creation and annihilation operators
             # on the boson operator 'b'
             if hterm.dag == "-":
-
                 # Iterate over the site indexes for the term's alpha-index
                 for loc, nval in np.ndenumerate(arr):
-
                     # Do not annihilate the vacuum, this term comes to 0
                     # anyway.
                     if nval == 0:
@@ -271,7 +268,6 @@ class Equation(MSONable):
                         self._terms_list.append(t)
 
             elif hterm.dag == "+":
-
                 # Don't want to create an equation corresponding to more than
                 # the maximum number of allowed phonons.
                 nphonons = self.index_term.config.total_phonons_per_type[bt]
@@ -380,7 +376,6 @@ class GreenEquation(Equation):
 
         # Iterate over all possible types of the coupling operators
         for hterm in self._model.hamiltonian.terms:
-
             # Only phonon creation terms contribute to the Green's function
             # EOM since annihilation terms hit the vacuum and yield zero.
             if hterm.dag == "+":

--- a/ggce/engine/system.py
+++ b/ggce/engine/system.py
@@ -155,7 +155,6 @@ class System:
                     self._f_arg_list[n_mat_id] = [delta]
 
     def _append_generalized_equation(self, n_phonons, config):
-
         eq = Equation.from_config(config, model=self._model)
 
         # Append a master dictionary at the System object level that
@@ -185,7 +184,6 @@ class System:
         return sum([len(ll) for ll in self._f_arg_list.values()])
 
     def _predict_total_terms(self):
-
         L = sum([len(val) for val in self._generalized_equations.values()])
 
         # Need to generalize this
@@ -215,7 +213,6 @@ class System:
             logger.info(f"Predicted {L} generalized equations")
 
     def _initialize_generalized_equations(self, allowed_configs):
-
         self._generalized_equations = {n: [] for n in allowed_configs.keys()}
 
         # Generate all possible numbers of phonons consistent with n_max.
@@ -233,7 +230,6 @@ class System:
         self._predict_total_terms()
 
     def _initialize_equations(self):
-
         totals = self._get_total_terms()
 
         # Initialize the self._equations attribute's lists here since we know
@@ -502,7 +498,6 @@ class System:
         basis = dict()
 
         if full_basis:
-
             # Set the overall basis. Each unique identifier gets its own .
             cc = 0
             for _, equations in self._equations.items():
@@ -511,7 +506,6 @@ class System:
                     cc += 1
 
         else:
-
             # Set the local basis, in which each identifier gets its own
             # relative to the n-phonon manifold.
             for n_phonons, list_of_equations in self._equations.items():

--- a/ggce/engine/terms.py
+++ b/ggce/engine/terms.py
@@ -40,7 +40,6 @@ def _check_config(config):
 
 
 def _config_edges_legal(config):
-
     # First, sum up over all of the phonon types. This produces the
     # "anchor" config.
     _config = config.sum(axis=0)
@@ -908,7 +907,6 @@ class NonIndexTerm(Term):
         self._modify_n_phonons_(*loc)
 
     def coefficient(self, k, w, eta):
-
         exp_arg = 1j * np.dot(k, self._lattice_constant * self.exp_shift)
         exp_term = cmath.exp(exp_arg)
 

--- a/ggce/executors/petsc4py/base.py
+++ b/ggce/executors/petsc4py/base.py
@@ -64,7 +64,6 @@ class MassSolver(Solver):
         return self._matr_dir
 
     def __init__(self, brigade_size=None, matr_dir=None, *args, **kwargs):
-
         super().__init__(*args, **kwargs)
         self._matr_dir = matr_dir
         if matr_dir is not None:
@@ -538,7 +537,7 @@ class MassSolver(Solver):
         self._total_jobs_on_this_brigade = len(jobs_on_brigade)
         # Get the results on this rank.
         s = []
-        for (_k, _w) in tqdm(jobs_on_brigade, disable=not pbar):
+        for _k, _w in tqdm(jobs_on_brigade, disable=not pbar):
             s.append(self.solve(_k, _w, eta))
 
         # Gather the results from the brigade commanders to "the general"
@@ -656,7 +655,7 @@ class MassSolver(Solver):
         )
 
         # Get the results on this rank.
-        for (_k, _w) in tqdm(jobs_on_brigade, disable=not pbar):
+        for _k, _w in tqdm(jobs_on_brigade, disable=not pbar):
             self.prepare_system(_k, _w, eta)
 
         return
@@ -668,7 +667,6 @@ class MassSolver(Solver):
 
     @staticmethod
     def _get_matr_size(matr_dir):
-
         """For use with the _scaffold_from_disk method. Helps figure
         out the ultimate matrix size before loading all in."""
 

--- a/ggce/executors/solvers.py
+++ b/ggce/executors/solvers.py
@@ -169,7 +169,7 @@ class BasicSolver(Solver):
         jobs_on_rank = self.get_jobs_on_this_rank(jobs)
 
         s = []
-        for (_k, _w) in tqdm(jobs_on_rank, disable=not pbar):
+        for _k, _w in tqdm(jobs_on_rank, disable=not pbar):
             s.append(self.solve(_k, _w, eta))
 
         if self.mpi_comm is not None:
@@ -370,7 +370,6 @@ class DenseSolver(BasicSolver):
             self._basis = self._system.get_basis(full_basis=False)
 
     def _fill_matrix(self, k, w, n_phonons, shift, eta):
-
         n_phonons_shift = n_phonons + shift
 
         equations_n = self._system.equations[n_phonons]
@@ -424,7 +423,6 @@ class DenseSolver(BasicSolver):
         # Solution ------------------------------------------------------------
         total_phonons = np.sum(self._system.model.phonon_number)
         for n_phonons in range(total_phonons, 0, -1):
-
             # Special case of the recursion where R_N = alpha_N.
             if n_phonons == total_phonons:
                 R = self._get_alpha(k, w, n_phonons, eta)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 dependencies = [
-    "numpy==1.23",
+    "numpy<1.24",
     "scipy",
     "loguru",
     "monty",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 dependencies = [
-    "numpy",
+    "numpy==1.23",
     "scipy",
     "loguru",
     "monty",


### PR DESCRIPTION
This should fix the issues with using numpy==1.24 with scipy. I.e., what is currently messing with the tests.