### PR TITLE
Fix to failing PETSc compile in tests

### DIFF
--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.11]
         mpi: ["openmpi"]
 
     steps:

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -89,7 +89,7 @@ jobs:
       run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
-      run: pip install "petsc==3.19.1" "petsc4py==3.19.1"/ --no-cache-dir --no-binary=petsc --no-binary=petsc4py
+      run: pip install "petsc==3.19.1" "petsc4py==3.19.1" --no-cache-dir --no-binary :all:
       env:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -88,7 +88,7 @@ jobs:
       run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
-      run: pip install --no-use-pep517 "petsc==3.18.4" "petsc4py==3.18.4"
+      run: pip install --no-use-pep517 "petsc==3.19.1" "petsc4py==3.19.1"
       env:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -88,7 +88,7 @@ jobs:
       run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
-      run: pip install --use-pep517 "petsc==3.18.4" "petsc4py==3.18.4"
+      run: pip install --no-use-pep517 "petsc==3.18.4" "petsc4py==3.18.4"
       env:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -89,7 +89,7 @@ jobs:
       run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
-      run: pip install "petsc==3.19.1" "petsc4py==3.19.1"
+      run: pip install "petsc==3.19.1" "petsc4py==3.19.1"/ --no-cache-dir --no-binary=petsc --no-binary=petsc4py
       env:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 
@@ -102,6 +102,6 @@ jobs:
     - name: Upload code coverage
       uses: codecov/codecov-action@v2
       timeout-minutes: 10
-      with:
+      with:i
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -89,7 +89,7 @@ jobs:
       run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
-      run: pip install --no-use-pep517 "petsc==3.19.1" "petsc4py==3.19.1"
+      run: pip install "petsc==3.19.1" "petsc4py==3.19.1"
       env:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
         mpi: ["openmpi"]
 
     steps:

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -89,7 +89,7 @@ jobs:
       run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
-      run: pip install "petsc==3.19.1" "petsc4py==3.19.1" --no-cache-dir --no-binary=petsc --no-binary=petsc4py
+      run: pip install "petsc==3.19.1" "petsc4py==3.19.1"/ --no-cache-dir --no-binary=petsc --no-binary=petsc4py
       env:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 
@@ -102,6 +102,6 @@ jobs:
     - name: Upload code coverage
       uses: codecov/codecov-action@v2
       timeout-minutes: 10
-      with:i
+      with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -54,6 +54,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9, "3.10", 3.11]

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -89,7 +89,7 @@ jobs:
       run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
-      run: pip install "petsc==3.19.1" "petsc4py==3.19.1"/ --no-cache-dir --no-binary=petsc --no-binary=petsc4py
+      run: pip install "petsc==3.19.1" "petsc4py==3.19.1" --no-cache-dir --no-binary=petsc --no-binary=petsc4py
       env:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -89,7 +89,7 @@ jobs:
       run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
-      run: pip install "petsc==3.19.1" "petsc4py==3.19.1" --no-cache-dir --no-binary :all:
+      run: pip install "petsc==3.19.1" "petsc4py==3.19.1" --no-cache-dir --no-binary=petsc --no-binary=petsc4py
       env:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, 3.11]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
         mpi: ["openmpi"]
 
     steps:

--- a/.github/workflows/ci_petsc.yml
+++ b/.github/workflows/ci_petsc.yml
@@ -88,7 +88,7 @@ jobs:
       run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
-      run: pip install "petsc==3.18.4" "petsc4py==3.18.4"
+      run: pip install --use-pep517 "petsc==3.18.4" "petsc4py==3.18.4"
       env:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 

--- a/MACE_Field_Tutorial.ipynb
+++ b/MACE_Field_Tutorial.ipynb
@@ -1,0 +1,1165 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4",
+      "authorship_tag": "ABX9TyNP4f6J1Yt02lYivA24RSS5",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/Neutrino155/GGCE/blob/master/MACE_Field_Tutorial.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# MACE Field Tutorial\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "9kY30kCYsWOE"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In this tutorial, we dive into the alterations we have made to the MACE model to incorporate an external perturbing electric field into the MACE architecture, and how to use it to derive derivative properties such as the macroscopic polarisation, Born Effective Charges (BECS) and polarisability."
+      ],
+      "metadata": {
+        "id": "QTndatuysl3C"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "To learn how the base MACE code works, we highly recommend you look at the [MACE theory tutorial](https://colab.research.google.com/drive/1AlfjQETV_jZ0JQnV5M3FGwAM2SGCl2aU) developed by Will Baldwin and Ilyes Batatia."
+      ],
+      "metadata": {
+        "id": "juQVIyxUs_d0"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Installs"
+      ],
+      "metadata": {
+        "id": "1JwZdoFffL5z"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!rm -rf /usr/local/lib/python3.11/site-packages/mace\n",
+        "!git clone https://github.com/mdi-group/mace-field-tutorial.git\n",
+        "!git clone https://github.com/mdi-group/mace-field.git\n",
+        "%cd mace-field\n",
+        "!git switch field\n",
+        "!pip install .\n",
+        "!pip install --force-reinstall numpy==2.0"
+      ],
+      "metadata": {
+        "id": "tzwwemRNslCz",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "d81504e7-8752-4d2e-f3ca-9e58c55dcf12"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Cloning into 'mace-field-tutorial'...\n",
+            "remote: Enumerating objects: 53, done.\u001b[K\n",
+            "remote: Counting objects: 100% (53/53), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (49/49), done.\u001b[K\n",
+            "remote: Total 53 (delta 23), reused 8 (delta 1), pack-reused 0 (from 0)\u001b[K\n",
+            "Receiving objects: 100% (53/53), 2.28 MiB | 10.60 MiB/s, done.\n",
+            "Resolving deltas: 100% (23/23), done.\n",
+            "Cloning into 'mace-field'...\n",
+            "remote: Enumerating objects: 6184, done.\u001b[K\n",
+            "remote: Counting objects: 100% (58/58), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (31/31), done.\u001b[K\n",
+            "remote: Total 6184 (delta 38), reused 29 (delta 27), pack-reused 6126 (from 3)\u001b[K\n",
+            "Receiving objects: 100% (6184/6184), 123.65 MiB | 26.49 MiB/s, done.\n",
+            "Resolving deltas: 100% (4643/4643), done.\n",
+            "Updating files: 100% (98/98), done.\n",
+            "/content/mace-field\n",
+            "Branch 'field' set up to track remote branch 'field' from 'origin'.\n",
+            "Switched to a new branch 'field'\n",
+            "Processing /content/mace-field\n",
+            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "Requirement already satisfied: torch>=1.12 in /usr/local/lib/python3.11/dist-packages (from mace-torch==0.3.10) (2.6.0+cu124)\n",
+            "Collecting e3nn==0.4.4 (from mace-torch==0.3.10)\n",
+            "  Downloading e3nn-0.4.4-py3-none-any.whl.metadata (5.1 kB)\n",
+            "Collecting numpy<2.0 (from mace-torch==0.3.10)\n",
+            "  Downloading numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (61 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m61.0/61.0 kB\u001b[0m \u001b[31m1.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: opt_einsum in /usr/local/lib/python3.11/dist-packages (from mace-torch==0.3.10) (3.4.0)\n",
+            "Collecting ase (from mace-torch==0.3.10)\n",
+            "  Downloading ase-3.25.0-py3-none-any.whl.metadata (4.2 kB)\n",
+            "Collecting torch-ema (from mace-torch==0.3.10)\n",
+            "  Downloading torch_ema-0.3-py3-none-any.whl.metadata (415 bytes)\n",
+            "Requirement already satisfied: prettytable in /usr/local/lib/python3.11/dist-packages (from mace-torch==0.3.10) (3.16.0)\n",
+            "Collecting matscipy (from mace-torch==0.3.10)\n",
+            "  Downloading matscipy-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (37 kB)\n",
+            "Requirement already satisfied: h5py in /usr/local/lib/python3.11/dist-packages (from mace-torch==0.3.10) (3.13.0)\n",
+            "Collecting torchmetrics (from mace-torch==0.3.10)\n",
+            "  Downloading torchmetrics-1.7.1-py3-none-any.whl.metadata (21 kB)\n",
+            "Collecting python-hostlist (from mace-torch==0.3.10)\n",
+            "  Downloading python-hostlist-2.2.1.tar.gz (37 kB)\n",
+            "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "Collecting configargparse (from mace-torch==0.3.10)\n",
+            "  Downloading ConfigArgParse-1.7-py3-none-any.whl.metadata (23 kB)\n",
+            "Requirement already satisfied: GitPython in /usr/local/lib/python3.11/dist-packages (from mace-torch==0.3.10) (3.1.44)\n",
+            "Requirement already satisfied: pyYAML in /usr/local/lib/python3.11/dist-packages (from mace-torch==0.3.10) (6.0.2)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.11/dist-packages (from mace-torch==0.3.10) (4.67.1)\n",
+            "Requirement already satisfied: matplotlib in /usr/local/lib/python3.11/dist-packages (from mace-torch==0.3.10) (3.10.0)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.11/dist-packages (from mace-torch==0.3.10) (2.2.2)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.11/dist-packages (from e3nn==0.4.4->mace-torch==0.3.10) (1.13.1)\n",
+            "Requirement already satisfied: scipy in /usr/local/lib/python3.11/dist-packages (from e3nn==0.4.4->mace-torch==0.3.10) (1.14.1)\n",
+            "Collecting opt-einsum-fx>=0.1.4 (from e3nn==0.4.4->mace-torch==0.3.10)\n",
+            "  Downloading opt_einsum_fx-0.1.4-py3-none-any.whl.metadata (3.3 kB)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.11/dist-packages (from torch>=1.12->mace-torch==0.3.10) (3.18.0)\n",
+            "Requirement already satisfied: typing-extensions>=4.10.0 in /usr/local/lib/python3.11/dist-packages (from torch>=1.12->mace-torch==0.3.10) (4.13.1)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.11/dist-packages (from torch>=1.12->mace-torch==0.3.10) (3.4.2)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.11/dist-packages (from torch>=1.12->mace-torch==0.3.10) (3.1.6)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.11/dist-packages (from torch>=1.12->mace-torch==0.3.10) (2025.3.2)\n",
+            "Collecting nvidia-cuda-nvrtc-cu12==12.4.127 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl.metadata (1.5 kB)\n",
+            "Collecting nvidia-cuda-runtime-cu12==12.4.127 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl.metadata (1.5 kB)\n",
+            "Collecting nvidia-cuda-cupti-cu12==12.4.127 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl.metadata (1.6 kB)\n",
+            "Collecting nvidia-cudnn-cu12==9.1.0.70 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl.metadata (1.6 kB)\n",
+            "Collecting nvidia-cublas-cu12==12.4.5.8 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl.metadata (1.5 kB)\n",
+            "Collecting nvidia-cufft-cu12==11.2.1.3 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl.metadata (1.5 kB)\n",
+            "Collecting nvidia-curand-cu12==10.3.5.147 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_x86_64.whl.metadata (1.5 kB)\n",
+            "Collecting nvidia-cusolver-cu12==11.6.1.9 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl.metadata (1.6 kB)\n",
+            "Collecting nvidia-cusparse-cu12==12.3.1.170 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl.metadata (1.6 kB)\n",
+            "Requirement already satisfied: nvidia-cusparselt-cu12==0.6.2 in /usr/local/lib/python3.11/dist-packages (from torch>=1.12->mace-torch==0.3.10) (0.6.2)\n",
+            "Requirement already satisfied: nvidia-nccl-cu12==2.21.5 in /usr/local/lib/python3.11/dist-packages (from torch>=1.12->mace-torch==0.3.10) (2.21.5)\n",
+            "Requirement already satisfied: nvidia-nvtx-cu12==12.4.127 in /usr/local/lib/python3.11/dist-packages (from torch>=1.12->mace-torch==0.3.10) (12.4.127)\n",
+            "Collecting nvidia-nvjitlink-cu12==12.4.127 (from torch>=1.12->mace-torch==0.3.10)\n",
+            "  Downloading nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl.metadata (1.5 kB)\n",
+            "Requirement already satisfied: triton==3.2.0 in /usr/local/lib/python3.11/dist-packages (from torch>=1.12->mace-torch==0.3.10) (3.2.0)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.11/dist-packages (from sympy->e3nn==0.4.4->mace-torch==0.3.10) (1.3.0)\n",
+            "Requirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.11/dist-packages (from matplotlib->mace-torch==0.3.10) (1.3.1)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.11/dist-packages (from matplotlib->mace-torch==0.3.10) (0.12.1)\n",
+            "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.11/dist-packages (from matplotlib->mace-torch==0.3.10) (4.57.0)\n",
+            "Requirement already satisfied: kiwisolver>=1.3.1 in /usr/local/lib/python3.11/dist-packages (from matplotlib->mace-torch==0.3.10) (1.4.8)\n",
+            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.11/dist-packages (from matplotlib->mace-torch==0.3.10) (24.2)\n",
+            "Requirement already satisfied: pillow>=8 in /usr/local/lib/python3.11/dist-packages (from matplotlib->mace-torch==0.3.10) (11.1.0)\n",
+            "Requirement already satisfied: pyparsing>=2.3.1 in /usr/local/lib/python3.11/dist-packages (from matplotlib->mace-torch==0.3.10) (3.2.3)\n",
+            "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.11/dist-packages (from matplotlib->mace-torch==0.3.10) (2.8.2)\n",
+            "Requirement already satisfied: gitdb<5,>=4.0.1 in /usr/local/lib/python3.11/dist-packages (from GitPython->mace-torch==0.3.10) (4.0.12)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.11/dist-packages (from pandas->mace-torch==0.3.10) (2025.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.11/dist-packages (from pandas->mace-torch==0.3.10) (2025.2)\n",
+            "Requirement already satisfied: wcwidth in /usr/local/lib/python3.11/dist-packages (from prettytable->mace-torch==0.3.10) (0.2.13)\n",
+            "Collecting lightning-utilities>=0.8.0 (from torchmetrics->mace-torch==0.3.10)\n",
+            "  Downloading lightning_utilities-0.14.3-py3-none-any.whl.metadata (5.6 kB)\n",
+            "Requirement already satisfied: smmap<6,>=3.0.1 in /usr/local/lib/python3.11/dist-packages (from gitdb<5,>=4.0.1->GitPython->mace-torch==0.3.10) (5.0.2)\n",
+            "Requirement already satisfied: setuptools in /usr/local/lib/python3.11/dist-packages (from lightning-utilities>=0.8.0->torchmetrics->mace-torch==0.3.10) (75.2.0)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.11/dist-packages (from python-dateutil>=2.7->matplotlib->mace-torch==0.3.10) (1.17.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.11/dist-packages (from jinja2->torch>=1.12->mace-torch==0.3.10) (3.0.2)\n",
+            "Downloading e3nn-0.4.4-py3-none-any.whl (387 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m387.7/387.7 kB\u001b[0m \u001b[31m16.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (18.3 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m18.3/18.3 MB\u001b[0m \u001b[31m36.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl (363.4 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m363.4/363.4 MB\u001b[0m \u001b[31m4.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl (13.8 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m13.8/13.8 MB\u001b[0m \u001b[31m83.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl (24.6 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m24.6/24.6 MB\u001b[0m \u001b[31m74.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl (883 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m883.7/883.7 kB\u001b[0m \u001b[31m48.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl (664.8 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m664.8/664.8 MB\u001b[0m \u001b[31m2.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl (211.5 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m211.5/211.5 MB\u001b[0m \u001b[31m6.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_x86_64.whl (56.3 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.3/56.3 MB\u001b[0m \u001b[31m12.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl (127.9 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m127.9/127.9 MB\u001b[0m \u001b[31m7.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl (207.5 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m207.5/207.5 MB\u001b[0m \u001b[31m5.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl (21.1 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m21.1/21.1 MB\u001b[0m \u001b[31m81.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading ase-3.25.0-py3-none-any.whl (3.0 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.0/3.0 MB\u001b[0m \u001b[31m74.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading ConfigArgParse-1.7-py3-none-any.whl (25 kB)\n",
+            "Downloading matscipy-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (448 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m448.8/448.8 kB\u001b[0m \u001b[31m32.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading torch_ema-0.3-py3-none-any.whl (5.5 kB)\n",
+            "Downloading torchmetrics-1.7.1-py3-none-any.whl (961 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m961.5/961.5 kB\u001b[0m \u001b[31m49.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading lightning_utilities-0.14.3-py3-none-any.whl (28 kB)\n",
+            "Downloading opt_einsum_fx-0.1.4-py3-none-any.whl (13 kB)\n",
+            "Building wheels for collected packages: mace-torch, python-hostlist\n",
+            "  Building wheel for mace-torch (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for mace-torch: filename=mace_torch-0.3.10-py3-none-any.whl size=159987 sha256=a74299fab5df209114570a2e7f60ba3b57cdb7caf2aea00f327269ea96a041df\n",
+            "  Stored in directory: /root/.cache/pip/wheels/fb/ff/27/a97f2258bc135695f8532fac0144fe221b7de21b4eeb0d7380\n",
+            "  Building wheel for python-hostlist (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for python-hostlist: filename=python_hostlist-2.2.1-py3-none-any.whl size=39603 sha256=9d8aedc03123e139eeb4d2a30f67ea8518b6a9cc21cde587a7785886def74917\n",
+            "  Stored in directory: /root/.cache/pip/wheels/df/d3/7c/23728e2c3ff6d2fcc1c8b8bb7a101fa205b2f7cd37431a938b\n",
+            "Successfully built mace-torch python-hostlist\n",
+            "Installing collected packages: python-hostlist, nvidia-nvjitlink-cu12, nvidia-curand-cu12, nvidia-cufft-cu12, nvidia-cuda-runtime-cu12, nvidia-cuda-nvrtc-cu12, nvidia-cuda-cupti-cu12, nvidia-cublas-cu12, numpy, lightning-utilities, configargparse, nvidia-cusparse-cu12, nvidia-cudnn-cu12, nvidia-cusolver-cu12, ase, torchmetrics, torch-ema, opt-einsum-fx, matscipy, e3nn, mace-torch\n",
+            "  Attempting uninstall: nvidia-nvjitlink-cu12\n",
+            "    Found existing installation: nvidia-nvjitlink-cu12 12.5.82\n",
+            "    Uninstalling nvidia-nvjitlink-cu12-12.5.82:\n",
+            "      Successfully uninstalled nvidia-nvjitlink-cu12-12.5.82\n",
+            "  Attempting uninstall: nvidia-curand-cu12\n",
+            "    Found existing installation: nvidia-curand-cu12 10.3.6.82\n",
+            "    Uninstalling nvidia-curand-cu12-10.3.6.82:\n",
+            "      Successfully uninstalled nvidia-curand-cu12-10.3.6.82\n",
+            "  Attempting uninstall: nvidia-cufft-cu12\n",
+            "    Found existing installation: nvidia-cufft-cu12 11.2.3.61\n",
+            "    Uninstalling nvidia-cufft-cu12-11.2.3.61:\n",
+            "      Successfully uninstalled nvidia-cufft-cu12-11.2.3.61\n",
+            "  Attempting uninstall: nvidia-cuda-runtime-cu12\n",
+            "    Found existing installation: nvidia-cuda-runtime-cu12 12.5.82\n",
+            "    Uninstalling nvidia-cuda-runtime-cu12-12.5.82:\n",
+            "      Successfully uninstalled nvidia-cuda-runtime-cu12-12.5.82\n",
+            "  Attempting uninstall: nvidia-cuda-nvrtc-cu12\n",
+            "    Found existing installation: nvidia-cuda-nvrtc-cu12 12.5.82\n",
+            "    Uninstalling nvidia-cuda-nvrtc-cu12-12.5.82:\n",
+            "      Successfully uninstalled nvidia-cuda-nvrtc-cu12-12.5.82\n",
+            "  Attempting uninstall: nvidia-cuda-cupti-cu12\n",
+            "    Found existing installation: nvidia-cuda-cupti-cu12 12.5.82\n",
+            "    Uninstalling nvidia-cuda-cupti-cu12-12.5.82:\n",
+            "      Successfully uninstalled nvidia-cuda-cupti-cu12-12.5.82\n",
+            "  Attempting uninstall: nvidia-cublas-cu12\n",
+            "    Found existing installation: nvidia-cublas-cu12 12.5.3.2\n",
+            "    Uninstalling nvidia-cublas-cu12-12.5.3.2:\n",
+            "      Successfully uninstalled nvidia-cublas-cu12-12.5.3.2\n",
+            "  Attempting uninstall: numpy\n",
+            "    Found existing installation: numpy 2.0.2\n",
+            "    Uninstalling numpy-2.0.2:\n",
+            "      Successfully uninstalled numpy-2.0.2\n",
+            "  Attempting uninstall: nvidia-cusparse-cu12\n",
+            "    Found existing installation: nvidia-cusparse-cu12 12.5.1.3\n",
+            "    Uninstalling nvidia-cusparse-cu12-12.5.1.3:\n",
+            "      Successfully uninstalled nvidia-cusparse-cu12-12.5.1.3\n",
+            "  Attempting uninstall: nvidia-cudnn-cu12\n",
+            "    Found existing installation: nvidia-cudnn-cu12 9.3.0.75\n",
+            "    Uninstalling nvidia-cudnn-cu12-9.3.0.75:\n",
+            "      Successfully uninstalled nvidia-cudnn-cu12-9.3.0.75\n",
+            "  Attempting uninstall: nvidia-cusolver-cu12\n",
+            "    Found existing installation: nvidia-cusolver-cu12 11.6.3.83\n",
+            "    Uninstalling nvidia-cusolver-cu12-11.6.3.83:\n",
+            "      Successfully uninstalled nvidia-cusolver-cu12-11.6.3.83\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "thinc 8.3.6 requires numpy<3.0.0,>=2.0.0, but you have numpy 1.26.4 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0mSuccessfully installed ase-3.25.0 configargparse-1.7 e3nn-0.4.4 lightning-utilities-0.14.3 mace-torch-0.3.10 matscipy-1.1.1 numpy-1.26.4 nvidia-cublas-cu12-12.4.5.8 nvidia-cuda-cupti-cu12-12.4.127 nvidia-cuda-nvrtc-cu12-12.4.127 nvidia-cuda-runtime-cu12-12.4.127 nvidia-cudnn-cu12-9.1.0.70 nvidia-cufft-cu12-11.2.1.3 nvidia-curand-cu12-10.3.5.147 nvidia-cusolver-cu12-11.6.1.9 nvidia-cusparse-cu12-12.3.1.170 nvidia-nvjitlink-cu12-12.4.127 opt-einsum-fx-0.1.4 python-hostlist-2.2.1 torch-ema-0.3 torchmetrics-1.7.1\n",
+            "Collecting numpy==2.0\n",
+            "  Downloading numpy-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m60.9/60.9 kB\u001b[0m \u001b[31m3.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading numpy-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (19.3 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m19.3/19.3 MB\u001b[0m \u001b[31m55.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: numpy\n",
+            "  Attempting uninstall: numpy\n",
+            "    Found existing installation: numpy 1.26.4\n",
+            "    Uninstalling numpy-1.26.4:\n",
+            "      Successfully uninstalled numpy-1.26.4\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "mace-torch 0.3.10 requires numpy<2.0, but you have numpy 2.0.0 which is incompatible.\n",
+            "matscipy 1.1.1 requires numpy<2.0.0,>=1.16.0, but you have numpy 2.0.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0mSuccessfully installed numpy-2.0.0\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import numpy as np\n",
+        "import torch\n",
+        "\n",
+        "# Add this line before importing e3nn\n",
+        "torch.serialization.add_safe_globals([slice])  # Allow the 'slice'\n",
+        "\n",
+        "import torch.nn.functional\n",
+        "from e3nn import o3\n",
+        "from matplotlib import pyplot as plt\n",
+        "\n",
+        "from ase.io import read, write\n",
+        "\n",
+        "from mace import data, modules, tools\n",
+        "from mace.tools import torch_geometric\n",
+        "torch.set_default_dtype(torch.float64)\n",
+        "\n",
+        "import warnings\n",
+        "warnings.filterwarnings(\"ignore\")\n",
+        "\n",
+        "from mace.cli.run_train import main as mace_run_train_main\n",
+        "import sys\n",
+        "import logging"
+      ],
+      "metadata": {
+        "id": "05ZUYWXHxK1d"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from typing import Any, Dict, Optional\n",
+        "from mace.tools.scatter import scatter_sum\n",
+        "from mace.modules.blocks import (\n",
+        "    LinearReadoutBlock,\n",
+        "    ScaleShiftBlock,\n",
+        ")\n",
+        "from mace.modules.utils import (\n",
+        "    get_edge_vectors_and_lengths,\n",
+        "    get_symmetric_displacement,\n",
+        ")\n",
+        "from mace.modules.models import (\n",
+        "    MACE,\n",
+        "    ScaleShiftFieldMACE\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "WCm8DnDny9ju"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Write Config for the Model"
+      ],
+      "metadata": {
+        "id": "mFPPYvCN9a6e"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%cd ../mace-field-tutorial\n",
+        "training_atoms = read(\"data/batio3/BaTiO3.xyz\", \":\")[:100]\n",
+        "validation_atoms = read(\"data/batio3/BaTiO3.xyz\", \":\")[-100:]\n",
+        "test_atoms = read(\"data/batio3/BaTiO3.xyz\", \":\")[-200:-100]\n",
+        "write(\"data/training_dataset.xyz\", training_atoms)\n",
+        "write(\"data/validation_dataset.xyz\", validation_atoms)\n",
+        "write(\"data/test_dataset.xyz\", test_atoms)\n",
+        "\n",
+        "atomic_numbers = []\n",
+        "train_configs = [data.config_from_atoms(atoms) for atoms in training_atoms]\n",
+        "valid_configs = [data.config_from_atoms(atoms) for atoms in validation_atoms]\n",
+        "test_configs = [data.config_from_atoms(atoms) for atoms in test_atoms]\n",
+        "for config in train_configs + valid_configs + test_configs:\n",
+        "    atomic_numbers.extend(config.atomic_numbers)\n",
+        "atomic_numbers = list(set(atomic_numbers))\n",
+        "z_table = tools.AtomicNumberTable(atomic_numbers)\n",
+        "atomic_numbers = sorted(np.array(z_table.zs).tolist())"
+      ],
+      "metadata": {
+        "id": "h2yz1bKJo6tG",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "908ab269-0d16-4db8-9bcc-c4148ce6f8b5"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "/content/mace-field-tutorial\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import yaml\n",
+        "\n",
+        "model_config = {\n",
+        "\"name\": \"mace_field\",\n",
+        "\"train_file\": \"data/training_dataset.xyz\",\n",
+        "\"test_file\": \"data/validation_dataset.xyz\",\n",
+        "\"valid_file\": \"data/test_dataset.xyz\",\n",
+        "\"E0s\": \"average\",\n",
+        "\"atomic_numbers\": str(atomic_numbers),\n",
+        "\"loss\": \"universal_field\",\n",
+        "\"energy_weight\": 0.0,\n",
+        "\"forces_weight\": 0.0,\n",
+        "\"stress_weight\": 0.0,\n",
+        "\"bec_weight\": 0.0,\n",
+        "\"polarisability_weight\": 0.0,\n",
+        "\"polarisation_weight\": 1e7,\n",
+        "\"compute_field\": True,\n",
+        "\"eval_interval\": 1,\n",
+        "\"error_table\": \"PerAtomRMSEstressvirialsfield\",\n",
+        "\"model\": \"ScaleShiftFieldMACE\",\n",
+        "\"interaction_first\": \"RealAgnosticResidualInteractionBlock\",\n",
+        "\"interaction\": \"RealAgnosticResidualInteractionBlock\",\n",
+        "\"num_interactions\": 2,\n",
+        "\"correlation\": 3,\n",
+        "\"r_max\": 6.0,\n",
+        "\"max_L\": 1,\n",
+        "\"max_ell\": 3,\n",
+        "\"num_channels\": 128,\n",
+        "\"num_radial_basis\": 10,\n",
+        "\"MLP_irreps\": \"16x0e\",\n",
+        "\"num_workers\": 1,\n",
+        "\"lr\": 0.05,\n",
+        "\"weight_decay\": 1e-8,\n",
+        "\"batch_size\": 1,\n",
+        "\"valid_batch_size\": 1,\n",
+        "\"max_num_epochs\": 50,\n",
+        "\"device\": \"cpu\",\n",
+        "\"seed\": 1,\n",
+        "}\n",
+        "\n",
+        "with open('train_mace_field.yml', 'w') as f:\n",
+        "    yaml.dump(model_config, f)"
+      ],
+      "metadata": {
+        "id": "O1tltlQf1Ezc"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Training a MACE Field model"
+      ],
+      "metadata": {
+        "id": "Jxp1cXk6q3DF"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def train_mace_field(config_file_path):\n",
+        "    logging.getLogger().handlers.clear()\n",
+        "    sys.argv = [\"program\", \"--config\", config_file_path]\n",
+        "    mace_run_train_main()"
+      ],
+      "metadata": {
+        "id": "cXyn3ar-rD39"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "train_mace_field(\"train_mace_field.yml\")"
+      ],
+      "metadata": {
+        "id": "ATPnMBN4rKYz",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "43a2aa65-aa5f-4abc-9e42-675570af6420"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "2025-04-16 09:55:13.558 INFO: ===========VERIFYING SETTINGS===========\n",
+            "2025-04-16 09:55:13.567 INFO: MACE version: 0.3.10\n",
+            "2025-04-16 09:55:13.574 INFO: Using CPU\n",
+            "2025-04-16 09:55:14.184 INFO: ===========LOADING INPUT DATA===========\n",
+            "2025-04-16 09:55:14.187 INFO: Using heads: ['default']\n",
+            "2025-04-16 09:55:14.189 INFO: =============    Processing head default     ===========\n",
+            "2025-04-16 09:55:14.205 INFO: Training set [1 configs, 1 energy, 252 forces] loaded from 'data/training_dataset.xyz'\n",
+            "2025-04-16 09:55:14.213 INFO: Validation set [1 configs, 1 energy, 120 forces] loaded from 'data/test_dataset.xyz'\n",
+            "2025-04-16 09:55:14.221 INFO: Test set (1 configs) loaded from 'data/validation_dataset.xyz':\n",
+            "2025-04-16 09:55:14.224 INFO: Default_default: 1 configs, 1 energy, 132 forces\n",
+            "2025-04-16 09:55:14.226 INFO: Total number of configurations: train=1, valid=1, tests=[Default_default: 1],\n",
+            "2025-04-16 09:55:14.228 INFO: Using atomic numbers from command line argument\n",
+            "2025-04-16 09:55:14.230 INFO: Atomic Numbers used: [3, 6, 8, 11, 17, 27, 30, 37, 41]\n",
+            "2025-04-16 09:55:14.232 INFO: Isolated Atomic Energies (E0s) not in training file, using command line argument\n",
+            "2025-04-16 09:55:14.235 INFO: Computing average Atomic Energies using least squares regression\n",
+            "2025-04-16 09:55:14.238 INFO: Atomic Energies used (z: eV) for head default: {3: 0.0, 6: 0.0, 8: 0.0, 11: 0.0, 17: -4.234004974603174, 27: 0.0, 30: -1.0585012436507935, 37: -2.117002487301587, 41: 0.0}\n",
+            "2025-04-16 09:55:14.284 INFO: Computing average number of neighbors\n",
+            "2025-04-16 09:55:14.516 INFO: Average number of neighbors: 25.238095238095237\n",
+            "2025-04-16 09:55:14.520 INFO: During training the following quantities will be reported: energy, forces, virials, stress, polarisation, bec, polarisability\n",
+            "2025-04-16 09:55:14.523 INFO: ===========MODEL DETAILS===========\n",
+            "2025-04-16 09:55:14.776 INFO: Building model\n",
+            "2025-04-16 09:55:14.782 INFO: Message passing with 128 channels and max_L=1 (128x0e+128x1o)\n",
+            "2025-04-16 09:55:14.786 INFO: 2 layers, each with correlation order: 3 (body order: 4) and spherical harmonics up to: l=3\n",
+            "2025-04-16 09:55:14.789 INFO: 10 radial and 5 basis functions\n",
+            "2025-04-16 09:55:14.793 INFO: Radial cutoff: 6.0 A (total receptive field for each atom: 12.0 A)\n",
+            "2025-04-16 09:55:14.797 INFO: Distance transform for radial basis functions: None\n",
+            "2025-04-16 09:55:14.800 INFO: Hidden irreps: 128x0e+128x1o\n",
+            "2025-04-16 09:55:20.588 INFO: Total number of parameters: 1037584\n",
+            "2025-04-16 09:55:20.590 INFO: \n",
+            "2025-04-16 09:55:20.592 INFO: ===========OPTIMIZER INFORMATION===========\n",
+            "2025-04-16 09:55:20.595 INFO: Using ADAM as parameter optimizer\n",
+            "2025-04-16 09:55:20.597 INFO: Batch size: 1\n",
+            "2025-04-16 09:55:20.600 INFO: Number of gradient updates: 50\n",
+            "2025-04-16 09:55:20.601 INFO: Learning rate: 0.05, weight decay: 1e-08\n",
+            "2025-04-16 09:55:20.604 INFO: UniversalFieldLoss(energy_weight=0.000, forces_weight=0.000, stress_weight=0.000, polarisation_weight=10000000.000, bec_weight=0.000, polarisability_weight=0.000)\n",
+            "2025-04-16 09:55:20.611 INFO: Using gradient clipping with tolerance=10.000\n",
+            "2025-04-16 09:55:20.612 INFO: \n",
+            "2025-04-16 09:55:20.613 INFO: ===========TRAINING===========\n",
+            "2025-04-16 09:55:20.618 INFO: Started training, reporting errors on validation set\n",
+            "2025-04-16 09:55:20.621 INFO: Loss metrics on validation set\n",
+            "2025-04-16 09:55:30.070 INFO: Initial: head: default, loss=0.00063964, RMSE_E_per_atom= 7671.96 meV, RMSE_F=   11.35 meV / A, RMSE_stress= 2106.50 meV / A^3, RMSE_polarisation=    0.45 meV / A^2, RMSE_BEC=    0.00 |e|, RMSE_polarisability=    0.00 A\n",
+            "2025-04-16 09:56:05.229 INFO: Epoch 0: head: default, loss=0.00067424, RMSE_E_per_atom= 7672.01 meV, RMSE_F=   11.32 meV / A, RMSE_stress= 2106.50 meV / A^3, RMSE_polarisation=    0.46 meV / A^2, RMSE_BEC=    0.00 |e|, RMSE_polarisability=    0.00 A\n",
+            "2025-04-16 09:56:41.187 INFO: Epoch 1: head: default, loss=0.00082049, RMSE_E_per_atom= 7672.00 meV, RMSE_F=   11.33 meV / A, RMSE_stress= 2106.51 meV / A^3, RMSE_polarisation=    0.51 meV / A^2, RMSE_BEC=    0.00 |e|, RMSE_polarisability=    0.00 A\n",
+            "2025-04-16 09:57:17.686 INFO: Epoch 2: head: default, loss=0.00093083, RMSE_E_per_atom= 7671.95 meV, RMSE_F=   11.36 meV / A, RMSE_stress= 2106.51 meV / A^3, RMSE_polarisation=    0.55 meV / A^2, RMSE_BEC=    0.00 |e|, RMSE_polarisability=    0.00 A\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Understanding the MACE Field Architecture"
+      ],
+      "metadata": {
+        "id": "BV3a4zmI-kMQ"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Theory"
+      ],
+      "metadata": {
+        "id": "jYNamAclWyXS"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Our approach inherits most of the original MACE architecture. The primary alteration is in the readout blocks where we include an additional energy term, $-\\Omega\\ \\mathbf{P} \\cdot \\mathcal{E}$, where $\\Omega$ is the unit-cell volume, $\\mathbf{P}$ is the macroscopic polarisation, and $\\mathcal{E}$ is an external electric field. This is all in analogy to the electric enthalpy functional from Density Functional Perturbation Theory (DFPT). Please see the [VASP wiki](https://www.vasp.at/wiki/index.php/Berry_phases_and_finite_electric_fields) for a good introduction to Berry Phases and finite electric fields in DFPT."
+      ],
+      "metadata": {
+        "id": "dt2F_YnjCiMv"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The molecular dipole moment is the sum of the ionic contributions, with bare ionic charge $-e Z_\\alpha$ and position $\\mathbf{R}_\\alpha$, and an electronic contribution from the first moment of the electronic charge density $\\rho(\\mathbf{r})$:\n"
+      ],
+      "metadata": {
+        "id": "SDSY9L-JHJAX"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "\\begin{aligned}\n",
+        "    \\mathbf{p} &= \\mathbf{p}_{\\text{ion}} + \\mathbf{p}_{\\text{el}}\\\\\n",
+        "    \\mathbf{p} &= -e \\sum_{\\alpha} Z_\\alpha \\mathbf{R}_\\alpha + \\int d\\mathbf{r}\\ \\mathbf{r}\\ \\rho(\\mathbf{r})\n",
+        "\\end{aligned}\n",
+        "\\end{equation}\n"
+      ],
+      "metadata": {
+        "id": "VDTOg973HOSX"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "where the polarisation density is then just this dipole moment divided by the total volume, $\\mathbf{P} = \\mathbf{p} / V$.\n"
+      ],
+      "metadata": {
+        "id": "PHKyj5fMIvXS"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We see that the molecular dipole $\\mathbf{p}_{\\text{ion}, \\alpha}$ has a contribution per ion. Just as we decompose the total energy of the system into contributions per ion or per \"node\", suppose we decompose the electronic dipole into contributions per node, $\\mathbf{p}_{\\text{el}, \\alpha}$."
+      ],
+      "metadata": {
+        "id": "qMSKxuprM7ZB"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Due to the Modern Theory of Polarisation, quantum polarisation is multivalued / \"ill-defined\" for infinite periodic systems. The electronic dipole cannot in principle be decomposed this way, but just as is the case for the total energy, we will do it anyway. To compensate, the loss term for the polarisation will only be defined modulo the polarisation quantum to account for this multivalueness."
+      ],
+      "metadata": {
+        "id": "tOwESbdeOx_h"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Alterations to MACE"
+      ],
+      "metadata": {
+        "id": "qfJx4iPUW1ha"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Each layer $1 \\leq t \\leq T$ of MACE contributes to the final energy readout $E_\\alpha$ for node $\\alpha$:"
+      ],
+      "metadata": {
+        "id": "BDjK_LrHDGNW"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "    E_\\alpha = E_\\alpha^{(0)} + E_\\alpha^{(1)} + \\dots + E_\\alpha^{(T)}\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "SdaWXOY0xqsD"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In a $T$-layer MACE, the readout is altered to include an additional perturbing term of a $K$-dimensional \"total atomic dipole\" feature $\\mathbf{p}_{\\alpha, k}$ for each node $\\alpha$, dot-producted with the external electric field $\\mathcal{E}$:"
+      ],
+      "metadata": {
+        "id": "0qa6znVcEF8H"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "  E_\\alpha(t) = \\mathcal{R}_t\\left(\\mathbf{h}_i^{(t)}\\right) =\n",
+        "    \\begin{cases}\n",
+        "    \\begin{aligned}\n",
+        "        &\\sum_{\\tilde{k}} W_{\\text{readout}, \\tilde{k}}^{(t)} \\left[ h_{\\alpha,\\tilde{k} 0 0}^{e, (t)} - \\mathbf{p}_{\\alpha, \\tilde{k}}^{(t)} \\cdot \\mathbf{\\mathcal{E}} \\right] \\qquad\\ \\text{if}\\ t<T, \\\\\n",
+        "        &\\text{MLP}_{\\text{readout}}^{(t)}\\left( \\left\\{ h_{\\alpha,k 0 0}^{e, (t)} - \\mathbf{p}_{\\alpha, k}^{(t)} \\cdot \\mathbf{\\mathcal{E}} \\right\\}_{k} \\right) \\quad \\text{if}\\ t = T.\n",
+        "    \\end{aligned}\n",
+        "    \\end{cases}\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "TxemPmYXx4SM"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Where in the final layer the electric field enters the nonlinear MLP."
+      ],
+      "metadata": {
+        "id": "SXn57KSLFqC4"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "After the higher body-order `node_feats` are produced from the standard `product` blocks in the MACE model, we linearly map them to two scalar features and one vector feature which we may relate to the local node energy \"$e$\", charge \"$q$\" and electronic dipole moment:"
+      ],
+      "metadata": {
+        "id": "Flfz8BrCFzUW"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "    \\left[ h_{\\alpha, k 0 0}^{e, (t)},\\ h_{\\alpha, k 0 0}^{q, (t)},\\ h_{\\alpha, k 1 m}^{(t)} \\right] = \\sum_{l \\tilde{m}} W^{l \\tilde{m}}_{0 0, 1 m} h^{(t)}_{\\alpha,kl\\tilde{m}}.\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "k_HXp55-6ev1"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Note that these are not complete readouts yet as we have not yet mixed the k channels."
+      ],
+      "metadata": {
+        "id": "gK170zm2GjpW"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "To extract these features, we need to initialise in `__init__()` a new readout:\n",
+        "\n",
+        "```\n",
+        "field_irreps = o3.Irreps(\"0e\") + o3.Irreps.spherical_harmonics(1)\n",
+        "field_irreps_out = o3.Irreps(f\"{num_channels * field_irreps}\").sort()[0].simplify()\n",
+        "\n",
+        "self.field_readout = LinearReadoutBlock(hidden_irreps, field_irreps_out)\n",
+        "```\n",
+        "\n",
+        "which gives us two $l=0$ scalars and a $l=1$ vector *without* mixing the channels.\n",
+        "\n",
+        "After we obtain `node_feats` from the `product` block, we obtain these additional features from:\n",
+        "\n",
+        "```\n",
+        "node_out = self.field_readout(node_feats, node_heads).reshape(node_feats.shape[0], -1, 5)\n",
+        "node_energy_feats, node_charge_feats, node_electronic_dipole_feats = node_out[:,:,0],  node_out[:,:,1], -node_out[:,:,2:]\n",
+        "```"
+      ],
+      "metadata": {
+        "id": "qpVs31AXP8y5"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We then define a total dipole moment feature as:"
+      ],
+      "metadata": {
+        "id": "agt8sQIEGoq2"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "    \\mathbf{p}^{(t)}_{\\alpha,k} = h^{q,(t)}_{\\alpha,k 0 0} \\mathbf{R}_{\\alpha} - \\mathbf{h}^{(t)}_{\\alpha,k 1},\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "n34HRFjs6mal"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "where the first term represents the ionic dipole contribution.\n",
+        "\n",
+        "In the code we have:\n",
+        "\n",
+        "```\n",
+        "node_atomic_dipole_feats = torch.einsum('ij,ik->ijk', node_charge_feats, data[\"positions\"])\n",
+        "node_dipole_feats = node_atomic_dipole_feats + node_electronic_dipole_feats           \n",
+        "```\n",
+        "\n",
+        "This \"total dipole\" acts as an atomic decomposition of the total macroscopic polarisation which, dot product with the external electric field, contributes to the total energy:"
+      ],
+      "metadata": {
+        "id": "ay2cOBe9GtCe"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "h_{\\alpha,\\tilde{k} 0 0}^{e, (t)} - \\mathbf{p}_{\\alpha, \\tilde{k}}^{(t)} \\cdot \\mathbf{\\mathcal{E}},\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "dB8w4Bp1fFqV"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "which we then feed into the final energy `readout` block which mixes the $k$ channels:\n",
+        "\n",
+        "```\n",
+        "node_energies = node_energy_feats - torch.einsum('ijk,k->ij', node_dipole_feats, data[\"electric_field\"])\n",
+        "node_energies = readout(node_energies, node_heads)[num_atoms_arange, node_heads]        \n",
+        "```"
+      ],
+      "metadata": {
+        "id": "SBNOEd_UgCMs"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Since we need the node features, `node_feats`, to always have a $l=1$ piece, we need to alter the final `interaction` and `product` blocks of MACE which originally only preserve the $l=0$ piece in the last layer $T$.\n",
+        "\n",
+        "Therefore, in `__init__()` in our new model `ScaleShiftFieldMACE` we also include:\n",
+        "```\n",
+        "self.interactions[-1].skip_tp = o3.FullyConnectedTensorProduct(\n",
+        "    hidden_irreps,\n",
+        "    self.interactions[-1].node_attrs_irreps,\n",
+        "    hidden_irreps,\n",
+        "    self.interactions[-1].cueq_config,\n",
+        ")\n",
+        "```\n",
+        "and\n",
+        "```\n",
+        "self.products[-1] = self.products[-2]\n",
+        "```"
+      ],
+      "metadata": {
+        "id": "Qcq7LUFlQCxp"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Finally, as our new `field_readout` is an intermediate step between the `product` block and the energy `readout`, we need to alter the `irreps_in` of the energy `readout` blocks:\n",
+        "```\n",
+        "for i in range(len(self.readouts)-1):\n",
+        "    self.readouts[i].linear = o3.Linear(f\"{num_channels}x0e\", f\"{len(self.heads)}x0e\")\n",
+        "\n",
+        "self.readouts[-1].linear_1 = o3.Linear(f\"{num_channels}x0e\", f\"{len(self.heads) * kwargs['MLP_irreps']}\")   \n",
+        "```"
+      ],
+      "metadata": {
+        "id": "WiA6QAlgQWQ5"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Deriving Polarisation, BECs and Polarisability as derivates of energy"
+      ],
+      "metadata": {
+        "id": "VRCahZILW7Uy"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The predicted energy $E$ depends upon the atomic positions $\\mathbf{R}_{\\alpha}$ and the external electric field $\\mathbf{\\mathcal{E}}$ to arbitrary order,\n",
+        "\n",
+        "\\begin{equation}\n",
+        "    E(\\{\\mathbf{R}_\\alpha\\}, \\mathbf{\\mathcal{E}}) = E^{(0)}(\\mathbf{\\mathcal{E}}) + \\sum_{\\alpha=1}^N E_{\\alpha}^{(0)}\\left( \\mathbf{R}_{\\alpha};\\  \\mathbf{\\mathcal{E}} \\right) + \\sum_{1 \\leq \\alpha \\leq \\beta \\leq N}^N E_{\\alpha, \\beta}^{(1)}\\left( \\mathbf{R}_{\\alpha}, \\mathbf{R}_{\\beta};\\ \\mathbf{\\mathcal{E}} \\right) + \\dots + \\mathcal{F}\\left[m^{(T)}\\left(\\mathbf{R}_{\\alpha_1}, \\dots, \\mathbf{R}_{\\alpha_N};\\  \\mathbf{\\mathcal{E}}\\right)\\right],\n",
+        "\\end{equation}  \n",
+        "\n",
+        "where $\\mathcal{F}$ is a general, learnable non-linear term (here evaluated using a MLP) that accounts for excluded higher-order terms."
+      ],
+      "metadata": {
+        "id": "ADYa2j80TpSL"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Therefore, we account for non-linear susceptibilities,\n",
+        "\n",
+        "\\begin{equation}\n",
+        "    \\mathbf{P}(\\{\\mathbf{R}_\\alpha\\}, \\mathbf{\\mathcal{E}}) = -\\frac{1}{\\Omega} \\mathbf{\\nabla}_{\\mathbf{\\mathcal{E}}} E(\\{\\mathbf{R}_\\alpha\\}, \\mathbf{\\mathcal{E}}) = \\mathbf{P}_0(\\{\\mathbf{R}_\\alpha\\}) + \\chi^{(1)}(\\{\\mathbf{R}_\\alpha\\}) \\cdot  \\mathbf{\\mathcal{E}} + \\mathbf{\\mathcal{E}} \\cdot \\chi^{(2)}(\\{\\mathbf{R}_\\alpha\\}) \\cdot  \\mathbf{\\mathcal{E}} + \\dots,\n",
+        "\\end{equation}\n",
+        "\n",
+        "where we see that the polarisability is the linear susceptibility term, $\\chi^{(1)} \\equiv \\alpha$."
+      ],
+      "metadata": {
+        "id": "ZjNaRQqzURq6"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The polarisation ($P_i$) is then derived from the derivative of the total energy with respect to the external electric field:"
+      ],
+      "metadata": {
+        "id": "aMXXNpiRUtW5"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "  P_i = -\\frac{1}{\\Omega} \\frac{\\partial E}{\\partial \\mathcal{E}_i},\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "eFRkpUJEVjvC"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "which we compute using the forward `autograd.grad` function:\n",
+        "\n",
+        "```\n",
+        "def compute_polarisation(\n",
+        "    energy: torch.Tensor,\n",
+        "    electric_field: torch.Tensor,\n",
+        "    cell: torch.Tensor,\n",
+        "    training: bool = True,\n",
+        ") -> torch.Tensor:\n",
+        "    \n",
+        "    volume = torch.linalg.det(cell.view(-1, 3, 3)).abs()\n",
+        "    \n",
+        "    polarisation = torch.autograd.grad(\n",
+        "        outputs=energy,  # [n_graphs, ]            \n",
+        "        inputs=electric_field,  # [3, ]\n",
+        "        grad_outputs=torch.ones_like(energy),\n",
+        "        retain_graph=training,  # Make sure the graph is not destroyed during training  \n",
+        "        create_graph=training,  # Create graph for higher derivatives\n",
+        "        allow_unused=True,\n",
+        "    )[0]\n",
+        "\n",
+        "    return -polarisation / volume\n",
+        "```\n"
+      ],
+      "metadata": {
+        "id": "4GkOrEFpV7d7"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The Born effective charges ($Z^*_{\\alpha,ij}$) and the polarisability tensor ($\\alpha_{ij}$) may then be derived from derivatives of the polarisation with respect to atom position and the electric field, respectively,"
+      ],
+      "metadata": {
+        "id": "89iOkk0TVf86"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "    Z^*_{\\alpha, ij} = -\\frac{1}{e}\\frac{\\partial^2 E}{\\partial \\mathcal{E}_i\\ \\partial R_{\\alpha,j}}\\bigg\\rvert_{\\mathbf{\\mathcal{E}}=\\mathbf{0}}\n",
+        "    = \\frac{1}{e} \\frac{\\partial F_i}{\\partial \\mathcal{E}_j}\\bigg\\rvert_{\\mathbf{\\mathcal{E}}=\\mathbf{0}} = \\frac{\\Omega}{e} \\frac{\\partial P_i}{\\partial R_{\\alpha, j}}\\bigg\\rvert_{\\mathbf{\\mathcal{E}}=\\mathbf{0}},\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "7MeYkAsPUwE5"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "    \\alpha_{ij} = - \\frac{1}{\\Omega} \\frac{\\partial^2 E}{\\partial \\mathcal{E}_i\\ \\partial \\mathcal{E}_j} = \\frac{\\partial P_i}{\\partial \\mathcal{E}_j},\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "TDK6zSQCUvCa"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "which are computed by looping over the $3$ dimensions of the polarisation vector:"
+      ],
+      "metadata": {
+        "id": "LsG47dL3WQKa"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "```\n",
+        "def compute_bec(\n",
+        "    polarisation: torch.Tensor,\n",
+        "    positions: torch.Tensor,\n",
+        "    cell: torch.Tensor,\n",
+        "    training: bool = True,\n",
+        ") -> torch.Tensor:\n",
+        "    \n",
+        "    volume = torch.linalg.det(cell.view(-1, 3, 3)).abs()\n",
+        "    \n",
+        "    bec_polar_list = []\n",
+        "    for d in range(3): # Loop over dimensions\n",
+        "        polar_component = polarisation[d]\n",
+        "        gradient = torch.autograd.grad(\n",
+        "            outputs=polar_component, # [n_graphs, 1]\n",
+        "            inputs=positions, # [n_nodes, 3]\n",
+        "            grad_outputs=torch.ones_like(polar_component),\n",
+        "            retain_graph=training,  # Make sure the graph is not destroyed during training\n",
+        "            create_graph=training,  # Create graph for higher derivatives\n",
+        "            allow_unused=True,\n",
+        "        )[0]\n",
+        "        bec_polar_list.append(gradient) # [n_nodes, 3]\n",
+        "        \n",
+        "    bec = torch.stack(bec_polar_list, dim=1) # [n_nodes, 3, 3]\n",
+        "\n",
+        "    return bec * volume\n",
+        "```"
+      ],
+      "metadata": {
+        "id": "10ahjMWdWfoJ"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "```\n",
+        "def compute_polarisability(\n",
+        "    polarisation: torch.Tensor,\n",
+        "    electric_field: torch.Tensor,\n",
+        "    training: bool = True,\n",
+        ") -> torch.Tensor:\n",
+        "    \n",
+        "    # Second derivatives (BEC and polarisability) computed for each polarisation component.   \n",
+        "    polarisability_list = []\n",
+        "    for d in range(3):\n",
+        "        polar_component = polarisation[d]\n",
+        "        grad_field = torch.autograd.grad(\n",
+        "            outputs=polar_component, # [n_graphs, 1]\n",
+        "            inputs=electric_field, # [3, ]\n",
+        "            grad_outputs=torch.ones_like(polar_component),\n",
+        "            retain_graph=training,  # Make sure the graph is not destroyed during training\n",
+        "            create_graph=training,  # Create graph for higher derivatives\n",
+        "            allow_unused=True,\n",
+        "        )[0]\n",
+        "        polarisability_list.append(grad_field) # [n_graphs, 3]\n",
+        "        \n",
+        "    polarisability = torch.stack(polarisability_list, dim=1)  # [n_graphs, 3, 3]\n",
+        "\n",
+        "    return polarisability\n",
+        "```"
+      ],
+      "metadata": {
+        "id": "Mr2e_vDwWk_i"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Additional Loss Term"
+      ],
+      "metadata": {
+        "id": "hg7FkGKqXFw6"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In addition to the original loss function for the energy, forces and stress, we include three additional terms to account for the polarisation, becs and polarisability:"
+      ],
+      "metadata": {
+        "id": "f_nQGAaSXPTz"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "\\begin{aligned}\n",
+        "    \\Delta \\mathcal{L} &= \\frac{\\lambda_P}{3 B} \\sum_{b=1}^{B} \\sum_{i=1}^3 \\left(\\left[-\\frac{1}{\\Omega}\\frac{\\partial E_b^{(\\text{pred})}}{\\partial \\mathcal{E}_i} - P^{(\\text{ref})}_{b,i}\\right] \\text{mod}\\ \\Delta P_{b,i} \\right)^2 + \\frac{\\lambda_Z}{9 B N} \\sum_{\\alpha=1}^{B \\cdot N} \\sum_{i=1}^3 \\sum_{j=1}^3 \\left(-\\frac{1}{e}\\frac{\\partial^2 E^{(\\text{pred})}}{\\partial \\mathcal{E}_i\\ \\partial R_{\\alpha,j}} - Z^{* (\\text{ref})}_{\\alpha, ij} \\right)^2 \\\\\n",
+        "    &+ \\frac{\\lambda_\\alpha}{9 B} \\sum_{b=1}^{B} \\sum_{i=1}^3 \\sum_{j=1}^3 \\left(-\\frac{1}{\\Omega}\\frac{\\partial^2 E_b^{(\\text{pred})}}{\\partial \\mathcal{E}_i\\ \\partial \\mathcal{E}_j} - \\alpha^{(\\text{ref})}_{b,ij} \\right)^2 .\n",
+        "\\end{aligned}\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "V-yjN44zXL_j"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Here $B$ is the size of the batch and $b$ the batch index. $N$ is the number of atoms in the graph. The $\\lambda$s are the weights which will be automatically set to zero if the relevant training data is absent. This means a mixed dataset can be used for training."
+      ],
+      "metadata": {
+        "id": "rvWFnHQ5XfSa"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Here we write the MSE loss, but other losses can be used. In the main code we actually use the `torch.nn.HuberLoss` Huber loss with $\\delta = 0.1$."
+      ],
+      "metadata": {
+        "id": "CbWw4YUEZ-YT"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The modulo $\\text{mod}\\ \\Delta P_{b,i}$ term tells the model that the polarisation may be multivalued due to the Berry Phase, where the $ \\Delta \\mathbf{P} $ term is the polarisation quantum:"
+      ],
+      "metadata": {
+        "id": "4weD7dfnYLwi"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\\begin{equation}\n",
+        "   \\Delta \\mathbf{P} = \\frac{e \\mathbf{R}}{\\Omega},\n",
+        "\\end{equation}"
+      ],
+      "metadata": {
+        "id": "xAZA2D3OYj_i"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "where $\\mathbf{R}$ is the lattice vector."
+      ],
+      "metadata": {
+        "id": "ugciiURfZCUs"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "To implement this, we `torch.repeat` the reference and predicted polarisation vectors into a $3\\times3$ matrices and compare their difference modulo the $3\\times3$ `Cell` object from the `ASE` `Atom` type , weighted by the volume:"
+      ],
+      "metadata": {
+        "id": "CD4bzIRUZI5i"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "```\n",
+        "# Calculate the polarisation quantum\n",
+        "cell = ref[\"cell\"].view(-1,3,3)\n",
+        "polarisation_quantum = cell / torch.linalg.det(cell).abs()\n",
+        "\n",
+        "# modulo ignore zero components to leave pol unfolded and avoid divide by 0\n",
+        "polarisation_quantum[polarisation_quantum == 0] = max(torch.cat((ref[\"polarisation\"], pred[\"polarisation\"]))) + 1.0\n",
+        "\n",
+        "# Expand polarisation to lattice (3x3 matrix) that is modulo the polarisation quantum. Any nan (due to divide by 0), set to zero.\n",
+        "ref_polarisation = ref[\"polarisation\"].repeat(3,1).view(-1,3,3)\n",
+        "pred_polarisation = pred[\"polarisation\"].repeat(3,1).view(-1,3,3)\n",
+        "\n",
+        "polarisation_loss = self.huber_loss((ref_polarisation - pred_polarisation).fmod(polarisation_quantum).nan_to_num(nan=0) / num_atoms, torch.zeros_like(ref_polarisation))\n",
+        "        \n",
+        "```"
+      ],
+      "metadata": {
+        "id": "XvweyiicZ5Oj"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The [`Cell` object](https://wiki.fysik.dtu.dk/ase/ase/cell.html) is simply the three lattice vectors forming a parallelepiped.\n",
+        "\n",
+        "The weird manipulation of the polarisation quantum here is just to avoid dividing by zero in the modulo and to ignore any null directions where the lattice vector has zero entries. The difference modulo the `Cell` object is the compared to a $3\\times3$ null matrix."
+      ],
+      "metadata": {
+        "id": "wWpPT25IanMD"
+      }
+    }
+  ]
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@ install_test_requirements_only () {
 
 install_requirements() {
     python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["project"]["dependencies"]))' | pip install -r /dev/stdin
-    python3 -m pip install --upgrade pip==23.0.1 --no-binary :all:
+    python3 -m pip install --upgrade cython pip==23.0.1 --no-binary :all:
 }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@ install_test_requirements_only () {
 
 install_requirements() {
     python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["project"]["dependencies"]))' | pip install -r /dev/stdin
-    python3 -m pip install --upgrade cython pip==23.0.1 --no-binary :all:
+    python3 -m pip install --upgrade pip==23.0.1
 }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@ install_test_requirements_only () {
 
 install_requirements() {
     python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["project"]["dependencies"]))' | pip install -r /dev/stdin
-    python3 -m pip install --upgrade pip==23.0.1 setuptools wheel
+    python3 -m pip install --upgrade pip==23.0.1 --no-binary :all:
 }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@ install_test_requirements_only () {
 
 install_requirements() {
     python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["project"]["dependencies"]))' | pip install -r /dev/stdin
-    python3 -m pip install --upgrade pip==23.0.1
+    python3 -m pip install --upgrade pip==23.0.1 setuptools wheel
 }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,7 @@ install_test_requirements_only () {
 
 install_requirements() {
     python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["project"]["dependencies"]))' | pip install -r /dev/stdin
+    python3 -m pip install --upgrade pip==23.0.1
 }
 
 


### PR DESCRIPTION
https://github.com/openjournals/joss-reviews/issues/5115

Some of the tests were failing with the error:

```Error: Failed building wheel for petsc.```

Looking at this merge request: https://gitlab.com/petsc/petsc/-/merge_requests/6333, it seems that the issue is that `petsc` does not have a `pyproject.toml` file. It seems the current way to fix this is to anchor to `pip@23.0.1` and use `--no-use-pep517` to actively ask `pip` to install using a legacy mode.

I found that this still seemed to fail for `python@3.10` when anchoring to `petsc==3.18.4`, but this didn't appear to be an issue when anchoring to the latest version `petsc==3.19.1`.

Unfortunately, the CI still fails to complete and errors with:

```Error: The operation was canceled.```

I think this is due to the CI tests taking too long (they seem to collectively cut out at 50 minutes). 

I think it would be a good idea to try to reduce the time it takes for the tests to complete.
